### PR TITLE
Updates to https and corrections

### DIFF
--- a/_posts/0000-01-01-Ayrshire.md
+++ b/_posts/0000-01-01-Ayrshire.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Ayrshire
-website: https://ayrshire.lug.org.uk
+website: http://ayrshire.lug.org.uk
 established_date: 2019/04
 status: Active
 last_update: 04/2019

--- a/_posts/0000-01-01-Birmingham.md
+++ b/_posts/0000-01-01-Birmingham.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Birmingham
-website: https://birmingham.lug.org.uk
+website: https://www.birminghamlug.org.uk/
 established_date: 2001/06
 status: Active
 last_update: 09/2016

--- a/_posts/0000-01-01-Bristol and Bath.md
+++ b/_posts/0000-01-01-Bristol and Bath.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Bristol and Bath
-website: https://www.bristol.lug.org.uk
+website: https://bristol.lug.org.uk
 established_date: 1998/06
 status: Active
 last_update: 02/2019

--- a/_posts/0000-01-01-Chelmer Linux and Android Users Group.md
+++ b/_posts/0000-01-01-Chelmer Linux and Android Users Group.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Chelmer Linux and Android Users Group
-website: https://www.linkedin.com/groups/Chelmer-Linux-Android-Users-Group-3963756
 established_date: 2011/06
 status: Starting
 last_update: 06/2011

--- a/_posts/0000-01-01-Colchester.md
+++ b/_posts/0000-01-01-Colchester.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Colchester
-website: https://colchester.lug.org.uk
 established_date: 2004/11
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Cowley Club, Brighton.md
+++ b/_posts/0000-01-01-Cowley Club, Brighton.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Cowley Club, Brighton
-website: https://cowleyclub.org.uk/?Library:Free_Software_Clinic
+website: https://cowley.club/news/event/free-software-clinic/
 established_date: ''
 status: Active
 last_update: 10/2015

--- a/_posts/0000-01-01-Doncaster & Scunthorpe.md
+++ b/_posts/0000-01-01-Doncaster & Scunthorpe.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Doncaster & Scunthorpe
-website: https://www.scundog.org/
 established_date: 1999/07
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Leicester.md
+++ b/_posts/0000-01-01-Leicester.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Leicester
-website: http://www.leicester.lug.org.uk
+website: https://www.leicester.lug.org.uk/
 established_date: 1999/09
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Lincolnshire.md
+++ b/_posts/0000-01-01-Lincolnshire.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Lincolnshire
-website: http://lincslug.org.uk
+website: https://lincslug.org.uk/
 established_date: ''
 status: Starting
 last_update: 03/2014

--- a/_posts/0000-01-01-Liverpool (LivLUG).md
+++ b/_posts/0000-01-01-Liverpool (LivLUG).md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Liverpool (LivLUG)
-website: http://www.livlug.org.uk
+website: https://livlug.org.uk/
 established_date: 2004/11
 status: Active
 last_update: 01/2015

--- a/_posts/0000-01-01-Milton Keynes.md
+++ b/_posts/0000-01-01-Milton Keynes.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Milton Keynes
-website: http://www.mk.lug.org.uk
+website: https://www.mk.lug.org.uk/
 established_date: 1999/01
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Newark.md
+++ b/_posts/0000-01-01-Newark.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Newark
-website: https://www.facebook.com/groups/284465954978157/
 established_date: 2001/06
 status: Active
 last_update: 07/2016

--- a/_posts/0000-01-01-North East Worcestershire.md
+++ b/_posts/0000-01-01-North East Worcestershire.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: North-East Worcestershire
-website: http://www.new.lug.org.uk
+website: https://www.new.lug.org.uk/
 established_date: 2011/01
 status: Starting
 last_update: 12/2011

--- a/_posts/0000-01-01-Nottingham.md
+++ b/_posts/0000-01-01-Nottingham.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Nottingham
-website: http://www.nottingham.lug.org.uk
+website: https://nlug.ml1.co.uk/
 established_date: 2000/03
 status: Active
 last_update: 05/2012

--- a/_posts/0000-01-01-Rossendale LUG.md
+++ b/_posts/0000-01-01-Rossendale LUG.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Rossendale LUG
-website: https://www.rosslug.org.uk
 established_date: 2010/10
 status: Active
 last_update: 02/2014

--- a/_posts/0000-01-01-Rustington.md
+++ b/_posts/0000-01-01-Rustington.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Rustington
-website: http://www.rustington.lug.org.uk
+website: https://www.rustington.lug.org.uk/
 established_date: 2010/10
 status: Starting
 last_update: 10/2010

--- a/_posts/0000-01-01-Sheffield.md
+++ b/_posts/0000-01-01-Sheffield.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Sheffield
-website: https://www.sheflug.org.uk/
+website: https://www.sheflug.org.uk/indexpage/
 established_date: 1999/01
 status: Active
 last_update: 12/2009


### PR DESCRIPTION
Updated to https where the link works - all have been tested. In a few cases there is no website there, but if the domain is registered I have left it (and migrated to https if the outcome is the same as the http one or better).

Some websites have redirects on them so these have been updated to the end result of the redirect.

Some websites are no longer registered or cannot be found on the social site that hosted them, so these links have been removed.